### PR TITLE
updated harvest

### DIFF
--- a/harvest/README.md
+++ b/harvest/README.md
@@ -11,11 +11,11 @@ This is a stand alone node [node.js](https://nodejs.org/) CLI (command line inte
 
 **The script goes thru the following steps:**
 
-- Builds a list of query URLs for OpenFDA `drug/event` resources
+- Builds a list of query URLs for OpenFDA `drug/event` resources to fetch all events for each day between a provided date range
 - Makes an initial call to the endpoint to determine total event count for each day
 - Builds a list of URLs for each day with the appropriate `skip` parameter to paginate thru the results
 - Consumes each URL to parse out the unique reactions called out in the drug/events
-- Takes the list of unique reactions and sends a POST request to the DRE `/reaction` API resource with each reaction term
+- Takes the list of unique reactions found for a given day and sends a POST request to the DRE `/reaction` API resource with each reaction term to force the Reaction Lookup API to populate the definition for each term  (if it isn't already in the lookup)
 
 
 ## Setup / Usage
@@ -30,13 +30,13 @@ This is a stand alone node [node.js](https://nodejs.org/) CLI (command line inte
 
 ```
 
-node prepopulateDictionary.js [dre_hostname] [openFDA_api_key] [FROM_YYYY] [TO_YYYY] 
+node prepopulateDictionary.js [dre_reaction_uri] [openFDA_api_key] [FROM_YYYY] [TO_YYYY] 
 
 ```
 
-**[dre_hostname]**  = hostname of where **DRE** is loaded (ex. http://localhost:3000)
+**[dre\_reaction\_uri]**  = uri of where **DRE** reaction endpoint (example: `http://localhost:3000/reaction`)
 
-**[openFDA_api_key]**  = your openFDA api_key
+**[openFDA\_api\_key]**  = your openFDA api_key
 
 **[FROM_YYYY]**  = from year `drug/events` where you would like to start 
 
@@ -50,6 +50,18 @@ node prepopulateDictionary.js [dre_hostname] [openFDA_api_key] [FROM_YYYY] [TO_Y
 - Since this can be a long running script, we recommend starting walking backward year to year (2014, 2013, etc.) and just running it for one year at at time (set the FROM_YYYY and TO_YYYY to the same 4-digit year)
 
 - At this time, the drug/events dataset only includes data from 2004 until 2014, so ranges outside of that will return no data
+
+## Final Note
+
+This script was designed to try to fetch all possible unique reactions for the provided time period.  
+
+However, due to the 5000 skip limit imposed by the OpenFDA API (https://opendata.stackexchange.com/questions/5440/openfda-api-including-the-skip-parameter-limit) there are some cases where the total events for a given day are greater than 5000.  This will result in the script being able to fetch and reactions which are in events > 5000.  
+
+But, this does not result in an issue with the DRE app because:
+
+- There is a good chance the reaction is called out in another event and will be found at some point during the harvest / warming process
+
+- The DRE APP / API is capable of fetching the reaction definitions at run-time in cases where the reaction has not been previously captured in the Reaction Lookup API
 
 
 


### PR DESCRIPTION
- handle 422 response (vs. 400) for duplicate
- input /reaction post uri, vs. just hostname in case the route is different on a server
- updated readme with changes and additional information
