### PR TITLE
Issue #264 caching fix

### DIFF
--- a/client/app/scripts/services/reactions.js
+++ b/client/app/scripts/services/reactions.js
@@ -12,7 +12,6 @@ angular
             var commonParams = {
                 method: 'GET',
                 responseType: 'json',
-                cache: true,
                 headers: {
                     'Content-Type': 'application/json',
                     'Accept': 'application/json'
@@ -26,7 +25,6 @@ angular
           var commonParams = {
               method: 'POST',
               responseType: 'json',
-              cache: true,
               headers: {
                   'Content-Type': 'application/json',
                   'Accept': 'application/json'


### PR DESCRIPTION
removed cache to refresh definitions list when a user adds a definition to a term without having to refresh the page.
